### PR TITLE
Prepare for automated builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ PYLINT=`which pylint`
 HEXAPARSE=./hexaparse.py
 
 DIST_DIR=dist
+BROWSER_VERS_STRING=`git describe --exact-match --abbrev=0 || git rev-parse --short HEAD`
+
 
 clean:
 	-rm -rf $(DIST_DIR)
@@ -44,4 +46,4 @@ dist: check_cluster clean unittests tags
 	cp README.md $(DIST_DIR)
 	cp -r stat_key_browser $(DIST_DIR)
 	cp -r web_app $(DIST_DIR)
-	zip -r isilon_stat_browser_$$(git describe --exact-match --abbrev=0).zip dist/*
+	zip -r isilon_stat_browser_$(BROWSER_VERS_STRING).zip dist/*

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PYLINT=`which pylint`
 HEXAPARSE=./hexaparse.py
 
 DIST_DIR=dist
-BROWSER_VERS_STRING=`git describe --exact-match --abbrev=0 || git rev-parse --short HEAD`
+BROWSER_VERS_STRING=`git describe --tags --exact-match --abbrev=0 || git rev-parse --short HEAD`
 
 
 clean:

--- a/stat_key_browser/cluster_config.py
+++ b/stat_key_browser/cluster_config.py
@@ -1,11 +1,15 @@
 import sys
 try:
-    import isi_sdk
+    import isi_sdk_7_2 as isi_sdk
 except ImportError as err:
-    print('Unable to import isi_sdk. Please install the Isilon SDK.')
-    print('See https://github.com/isilon')
-    print(err)
-    sys.exit(1)
+    try:
+        # Try the original SDK library name
+        import isi_sdk
+    except ImportError as err:
+        print('Unable to import isi_sdk_7_2. Please install the Isilon SDK.')
+        print('See https://github.com/isilon')
+        print(err)
+        sys.exit(1)
 
 
 class ApiException(Exception):

--- a/stat_key_browser/key_collector.py
+++ b/stat_key_browser/key_collector.py
@@ -9,12 +9,16 @@ import re
 import logging
 import sys
 try:
-    import isi_sdk
+    import isi_sdk_7_2 as isi_sdk
 except ImportError as err:
-    print('Unable to import isi_sdk. Please install the Isilon SDK.')
-    print('See https://github.com/isilon')
-    print(err)
-    sys.exit(1)
+    try:
+        # Try the original SDK library name
+        import isi_sdk
+    except ImportError as err:
+        print('Unable to import isi_sdk_7_2. Please install the Isilon SDK.')
+        print('See https://github.com/isilon')
+        print(err)
+        sys.exit(1)
 
 PRIMARY = 0
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -1,1 +1,3 @@
-pass
+class TestBrowserBuilderFunctional(object):
+    def test_001_stub(self):
+        pass


### PR DESCRIPTION
## Summary
Stat Browser needs some preparation for the new automated build processes. 

* Import `isi_sdk_7_2` instead of the soon-to-be deprecated `isi_sdk`
* `make dist` names output based on current release tag, or commit SHA for non-release builds. 
* A stub is added for future automated functional testing

Imports of the SDK fall back to `isi_sdk` so that build_stat_browser.py will continue to function where only the old SDK language bindings are installed. 


## Testing
### Works with `isi_sdk_7_2`
```
chrismac:isilon_stat_browser isi-cbrainerd$ python -c 'import isi_sdk_7_2'
chrismac:isilon_stat_browser isi-cbrainerd$ python -c 'import isi_sdk'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named isi_sdk
chrismac:isilon_stat_browser isi-cbrainerd$ ./build_stat_browser.py -c 10.7.145.158 -u root -p a -x
2016-06-08T13:37:03 [INFO] Writing html to web_app/index.html
```

### Falls back to `isi_sdk` if needed
```
(env) chrismac:isilon_stat_browser isi-cbrainerd$ python -c 'import isi_sdk'
(env) chrismac:isilon_stat_browser isi-cbrainerd$ python -c 'import isi_sdk_7_2'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named isi_sdk_7_2
(env) chrismac:isilon_stat_browser isi-cbrainerd$ ./build_stat_browser.py -c 10.7.145.158 -u root -p a -x
2016-06-08T13:41:11 [INFO] Writing html to web_app/index.html
(env) chrismac:isilon_stat_browser isi-cbrainerd$
```