### PR TITLE
Update tests to work with pylint-1.6.4 and isi_sdk_7_2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ tags:
 	$(HEXAPARSE) stat_key_browser/data/key_cats.hexa > stat_key_browser/data/key_cats.json
 
 lint:
-	$(PYLINT) -E -f colorized -r n stat_key_browser bin/ tests/
+	$(PYLINT) -E -f colorized -r n stat_key_browser tests/
 
 unittests: lint
 	$(PYTHON) -m pytest -v tests/unit/ *.py

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ You can also generate the stat browser from your OneFS cluster by running the bu
 ### Requirements
 Python: 2.7, 3.3, 3.4, 3.5
 
-Isilon SDK Python Language Bindings installed
+Isilon SDK Python Language Bindings installed:
+
+`pip install isi_sdk_7_2`
 
 ### Generating the stat browser
 
@@ -60,8 +62,7 @@ The script will prompt you for a username and password, and will create the brow
 
 You can use the SDK Python language bindings to automate the configuration, maintenance, and monitoring of your Isilon cluster. For information on how to install the Python language bindings and write Python scripts to access the OneFS API, refer to the following Github sites:
 
-[`https://github.com/Isilon/isilon_sdk_7_2_python`](https://github.com/Isilon/isilon_sdk_7_2_python)
-[`https://github.com/Isilon/isilon_sdk_8_0_python`](https://github.com/Isilon/isilon_sdk_8_0_python)
+[`https://github.com/Isilon/isilon_sdk`](https://github.com/Isilon/isilon_sdk)
 
 
 Copyright (c) 2016 EMC Corporation

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ mock>=2.0.0
 jinja2>=2.8
 pylint>=1.5.5
 urllib3 >= 1.15
+isi_sdk_7_2>=0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 future>=0.15.2
 jinja2>=2.8
-urllib3 >= 1.15
+urllib3>=1.15
+isi_sdk_7_2>=0.1.2

--- a/tests/unit/test_cluster_config.py
+++ b/tests/unit/test_cluster_config.py
@@ -18,7 +18,7 @@ class TestClusterConfig(object):
         assert results == '1.0'
 
 
-    @patch('isi_sdk.ClusterApi.get_cluster_config')
+    @patch('isi_sdk_7_2.ClusterApi.get_cluster_config')
     def test_1_get_cluster_version(self, cluster_vers):
         canned = {'onefs_version': {'release': '1.0'}}
         response = MockClusterVersionResponse(canned)
@@ -26,7 +26,7 @@ class TestClusterConfig(object):
         results = cluster_config._get_cluster_version('4.3.2.1', 'u', 'p')
         assert results == '1.0'
 
-    @patch('isi_sdk.ClusterApi.get_cluster_config')
+    @patch('isi_sdk_7_2.ClusterApi.get_cluster_config')
     def test_3_get_cluster_versions_bug_169014(self, cluster_vers):
         response = MockClusterVersionResponse({})
         cluster_vers.return_value = response

--- a/tests/unit/test_key_collector.py
+++ b/tests/unit/test_key_collector.py
@@ -1,5 +1,5 @@
 from mock import patch
-import isi_sdk
+import isi_sdk_7_2
 import unittest
 import stat_key_browser.key_collector as key_collector
 
@@ -115,7 +115,7 @@ class TestKeyCollector(unittest.TestCase):
         assert 'a.a' in result
         mock_method.assert_called_with('testing123', 'user1', 'pass1')
 
-    @patch.object(isi_sdk, 'ApiClient')
+    @patch.object(isi_sdk_7_2, 'ApiClient')
     def test_get_key_list_1(self, mock_method):
         key_collector._get_key_list('testing123', 'user', 'pass')
         mock_method.assert_called_with('https://testing123:8080')


### PR DESCRIPTION
Fixes #11 and #13 

- Fix lint runs by adding a missing \_\_init\_\_.py and removing a deleted path from `make lint` recipe
- Update README to point to new isilon_sdk repo
- Add pip installable isi_sdk_7_2 to requirements.txt
- Update unittests to work with isi_sdk_7_2